### PR TITLE
Consolidate tests

### DIFF
--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -474,7 +474,6 @@ class AndroidTVDevice(ADBDevice):
             aftv, name, apps, get_sources, turn_on_command, turn_off_command
         )
 
-        self._device = None
         self._is_volume_muted = None
         self._volume_level = None
 
@@ -500,7 +499,7 @@ class AndroidTVDevice(ADBDevice):
             state,
             self._current_app,
             running_apps,
-            self._device,
+            _,
             self._is_volume_muted,
             self._volume_level,
         ) = self.aftv.update(self._get_sources)

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -287,9 +287,9 @@ async def test_setup_with_adbkey(hass):
         assert state.state == STATE_OFF
 
 
-async def test_androidtv_sources(hass):
-    """Test that sources (i.e., apps) are handled correctly for Android TV devices."""
-    config = CONFIG_ANDROIDTV_ADB_SERVER.copy()
+async def _test_sources(hass, config0):
+    """Test that sources (i.e., apps) are handled correctly for Android TV and Fire TV devices."""
+    config = config0.copy()
     config[DOMAIN][CONF_APPS] = {"com.app.test1": "TEST 1"}
     patch_key, entity_id = _setup(hass, config)
 
@@ -302,34 +302,66 @@ async def test_androidtv_sources(hass):
         assert state is not None
         assert state.state == STATE_OFF
 
-    with patchers.patch_androidtv_update(
-        "playing", "com.app.test1", ["com.app.test1", "com.app.test2"], "hdmi", False, 1
-    ):
+    if config[DOMAIN].get(CONF_DEVICE_CLASS) != "firetv":
+        patch_update = patchers.patch_androidtv_update(
+            "playing",
+            "com.app.test1",
+            ["com.app.test1", "com.app.test2"],
+            "hdmi",
+            False,
+            1,
+        )
+    else:
+        patch_update = patchers.patch_firetv_update(
+            "playing", "com.app.test1", ["com.app.test1", "com.app.test2"]
+        )
+
+    with patch_update:
         await hass.helpers.entity_component.async_update_entity(entity_id)
         state = hass.states.get(entity_id)
         assert state is not None
         assert state.state == STATE_PLAYING
         assert state.attributes["source"] == "TEST 1"
         assert state.attributes["source_list"] == ["TEST 1", "com.app.test2"]
-        assert not state.attributes["is_volume_muted"]
-        assert state.attributes["volume_level"] == 1
 
-    with patchers.patch_androidtv_update(
-        "playing", "com.app.test2", ["com.app.test2", "com.app.test1"], "hdmi", True, 0
-    ):
+    if config[DOMAIN].get(CONF_DEVICE_CLASS) != "firetv":
+        patch_update = patchers.patch_androidtv_update(
+            "playing",
+            "com.app.test2",
+            ["com.app.test2", "com.app.test1"],
+            "hdmi",
+            True,
+            0,
+        )
+    else:
+        patch_update = patchers.patch_firetv_update(
+            "playing", "com.app.test2", ["com.app.test2", "com.app.test1"]
+        )
+
+    with patch_update:
         await hass.helpers.entity_component.async_update_entity(entity_id)
         state = hass.states.get(entity_id)
         assert state is not None
         assert state.state == STATE_PLAYING
         assert state.attributes["source"] == "com.app.test2"
         assert state.attributes["source_list"] == ["com.app.test2", "TEST 1"]
-        assert state.attributes["is_volume_muted"]
-        assert state.attributes["volume_level"] == 0
+
+    return True
 
 
-async def _test_androidtv_select_source(hass, source, expected_arg, method_patch):
-    """Test that the `AndroidTV.launch_app` and `AndroidTV.stop_app` methods are called with the right parameter."""
-    config = CONFIG_ANDROIDTV_ADB_SERVER.copy()
+async def test_androidtv_sources(hass):
+    """Test that sources (i.e., apps) are handled correctly for Android TV devices."""
+    assert await _test_sources(hass, CONFIG_ANDROIDTV_ADB_SERVER)
+
+
+async def test_firetv_sources(hass):
+    """Test that sources (i.e., apps) are handled correctly for Fire TV devices."""
+    assert await _test_sources(hass, CONFIG_FIRETV_ADB_SERVER)
+
+
+async def _test_select_source(hass, config0, source, expected_arg, method_patch):
+    """Test that the methods for launching and stopping apps are called correctly when selecting a source."""
+    config = config0.copy()
     config[DOMAIN][CONF_APPS] = {"com.app.test1": "TEST 1"}
     patch_key, entity_id = _setup(hass, config)
 
@@ -356,146 +388,131 @@ async def _test_androidtv_select_source(hass, source, expected_arg, method_patch
 
 async def test_androidtv_select_source_launch_app_id(hass):
     """Test that an app can be launched using its app ID."""
-    assert await _test_androidtv_select_source(
-        hass, "com.app.test1", "com.app.test1", patchers.PATCH_LAUNCH_APP
+    assert await _test_select_source(
+        hass,
+        CONFIG_ANDROIDTV_ADB_SERVER,
+        "com.app.test1",
+        "com.app.test1",
+        patchers.PATCH_LAUNCH_APP,
     )
 
 
 async def test_androidtv_select_source_launch_app_name(hass):
     """Test that an app can be launched using its friendly name."""
-    assert await _test_androidtv_select_source(
-        hass, "TEST 1", "com.app.test1", patchers.PATCH_LAUNCH_APP
+    assert await _test_select_source(
+        hass,
+        CONFIG_ANDROIDTV_ADB_SERVER,
+        "TEST 1",
+        "com.app.test1",
+        patchers.PATCH_LAUNCH_APP,
     )
 
 
 async def test_androidtv_select_source_launch_app_id_no_name(hass):
     """Test that an app can be launched using its app ID when it has no friendly name."""
-    assert await _test_androidtv_select_source(
-        hass, "com.app.test2", "com.app.test2", patchers.PATCH_LAUNCH_APP
+    assert await _test_select_source(
+        hass,
+        CONFIG_ANDROIDTV_ADB_SERVER,
+        "com.app.test2",
+        "com.app.test2",
+        patchers.PATCH_LAUNCH_APP,
     )
 
 
 async def test_androidtv_select_source_stop_app_id(hass):
     """Test that an app can be stopped using its app ID."""
-    assert await _test_androidtv_select_source(
-        hass, "!com.app.test1", "com.app.test1", patchers.PATCH_STOP_APP
+    assert await _test_select_source(
+        hass,
+        CONFIG_ANDROIDTV_ADB_SERVER,
+        "!com.app.test1",
+        "com.app.test1",
+        patchers.PATCH_STOP_APP,
     )
 
 
 async def test_andoirdtv_select_source_stop_app_name(hass):
     """Test that an app can be stopped using its friendly name."""
-    assert await _test_androidtv_select_source(
-        hass, "!TEST 1", "com.app.test1", patchers.PATCH_STOP_APP
+    assert await _test_select_source(
+        hass,
+        CONFIG_ANDROIDTV_ADB_SERVER,
+        "!TEST 1",
+        "com.app.test1",
+        patchers.PATCH_STOP_APP,
     )
 
 
 async def test_androidtv_select_source_stop_app_id_no_name(hass):
     """Test that an app can be stopped using its app ID when it has no friendly name."""
-    assert await _test_androidtv_select_source(
-        hass, "!com.app.test2", "com.app.test2", patchers.PATCH_STOP_APP
+    assert await _test_select_source(
+        hass,
+        CONFIG_ANDROIDTV_ADB_SERVER,
+        "!com.app.test2",
+        "com.app.test2",
+        patchers.PATCH_STOP_APP,
     )
-
-
-async def test_firetv_sources(hass):
-    """Test that sources (i.e., apps) are handled correctly for Fire TV devices."""
-    config = CONFIG_FIRETV_ADB_SERVER.copy()
-    config[DOMAIN][CONF_APPS] = {"com.app.test1": "TEST 1"}
-    patch_key, entity_id = _setup(hass, config)
-
-    with patchers.PATCH_ADB_DEVICE, patchers.patch_connect(True)[
-        patch_key
-    ], patchers.patch_shell("")[patch_key]:
-        assert await async_setup_component(hass, DOMAIN, config)
-        await hass.helpers.entity_component.async_update_entity(entity_id)
-        state = hass.states.get(entity_id)
-        assert state is not None
-        assert state.state == STATE_OFF
-
-    with patchers.patch_firetv_update(
-        "playing", "com.app.test1", ["com.app.test1", "com.app.test2"]
-    ):
-        await hass.helpers.entity_component.async_update_entity(entity_id)
-        state = hass.states.get(entity_id)
-        assert state is not None
-        assert state.state == STATE_PLAYING
-        assert state.attributes["source"] == "TEST 1"
-        assert state.attributes["source_list"] == ["TEST 1", "com.app.test2"]
-
-    with patchers.patch_firetv_update(
-        "playing", "com.app.test2", ["com.app.test2", "com.app.test1"]
-    ):
-        await hass.helpers.entity_component.async_update_entity(entity_id)
-        state = hass.states.get(entity_id)
-        assert state is not None
-        assert state.state == STATE_PLAYING
-        assert state.attributes["source"] == "com.app.test2"
-        assert state.attributes["source_list"] == ["com.app.test2", "TEST 1"]
-
-
-async def _test_firetv_select_source(hass, source, expected_arg, method_patch):
-    """Test that the `FireTV.launch_app` and `FireTV.stop_app` methods are called with the right parameter."""
-    config = CONFIG_FIRETV_ADB_SERVER.copy()
-    config[DOMAIN][CONF_APPS] = {"com.app.test1": "TEST 1"}
-    patch_key, entity_id = _setup(hass, config)
-
-    with patchers.PATCH_ADB_DEVICE, patchers.patch_connect(True)[
-        patch_key
-    ], patchers.patch_shell("")[patch_key]:
-        assert await async_setup_component(hass, DOMAIN, config)
-        await hass.helpers.entity_component.async_update_entity(entity_id)
-        state = hass.states.get(entity_id)
-        assert state is not None
-        assert state.state == STATE_OFF
-
-    with method_patch as method_patch_:
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_SELECT_SOURCE,
-            {ATTR_ENTITY_ID: entity_id, ATTR_INPUT_SOURCE: source},
-            blocking=True,
-        )
-        method_patch_.assert_called_with(expected_arg)
-
-    return True
 
 
 async def test_firetv_select_source_launch_app_id(hass):
     """Test that an app can be launched using its app ID."""
-    assert await _test_firetv_select_source(
-        hass, "com.app.test1", "com.app.test1", patchers.PATCH_LAUNCH_APP
+    assert await _test_select_source(
+        hass,
+        CONFIG_FIRETV_ADB_SERVER,
+        "com.app.test1",
+        "com.app.test1",
+        patchers.PATCH_LAUNCH_APP,
     )
 
 
 async def test_firetv_select_source_launch_app_name(hass):
     """Test that an app can be launched using its friendly name."""
-    assert await _test_firetv_select_source(
-        hass, "TEST 1", "com.app.test1", patchers.PATCH_LAUNCH_APP
+    assert await _test_select_source(
+        hass,
+        CONFIG_FIRETV_ADB_SERVER,
+        "TEST 1",
+        "com.app.test1",
+        patchers.PATCH_LAUNCH_APP,
     )
 
 
 async def test_firetv_select_source_launch_app_id_no_name(hass):
     """Test that an app can be launched using its app ID when it has no friendly name."""
-    assert await _test_firetv_select_source(
-        hass, "com.app.test2", "com.app.test2", patchers.PATCH_LAUNCH_APP
+    assert await _test_select_source(
+        hass,
+        CONFIG_FIRETV_ADB_SERVER,
+        "com.app.test2",
+        "com.app.test2",
+        patchers.PATCH_LAUNCH_APP,
     )
 
 
 async def test_firetv_select_source_stop_app_id(hass):
     """Test that an app can be stopped using its app ID."""
-    assert await _test_firetv_select_source(
-        hass, "!com.app.test1", "com.app.test1", patchers.PATCH_STOP_APP
+    assert await _test_select_source(
+        hass,
+        CONFIG_FIRETV_ADB_SERVER,
+        "!com.app.test1",
+        "com.app.test1",
+        patchers.PATCH_STOP_APP,
     )
 
 
 async def test_firetv_select_source_stop_app_name(hass):
     """Test that an app can be stopped using its friendly name."""
-    assert await _test_firetv_select_source(
-        hass, "!TEST 1", "com.app.test1", patchers.PATCH_STOP_APP
+    assert await _test_select_source(
+        hass,
+        CONFIG_FIRETV_ADB_SERVER,
+        "!TEST 1",
+        "com.app.test1",
+        patchers.PATCH_STOP_APP,
     )
 
 
 async def test_firetv_select_source_stop_app_id_no_name(hass):
     """Test that an app can be stopped using its app ID when it has no friendly name."""
-    assert await _test_firetv_select_source(
-        hass, "!com.app.test2", "com.app.test2", patchers.PATCH_STOP_APP
+    assert await _test_select_source(
+        hass,
+        CONFIG_FIRETV_ADB_SERVER,
+        "!com.app.test2",
+        "com.app.test2",
+        patchers.PATCH_STOP_APP,
     )

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -430,7 +430,7 @@ async def test_androidtv_select_source_stop_app_id(hass):
     )
 
 
-async def test_andoirdtv_select_source_stop_app_name(hass):
+async def test_androidtv_select_source_stop_app_name(hass):
     """Test that an app can be stopped using its friendly name."""
     assert await _test_select_source(
         hass,


### PR DESCRIPTION
## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
