### PR TITLE
Add remote platform to Vizio integration

### DIFF
--- a/homeassistant/components/vizio/__init__.py
+++ b/homeassistant/components/vizio/__init__.py
@@ -31,7 +31,7 @@ from .services import async_setup_services
 DATA_APPS: HassKey[VizioAppsDataUpdateCoordinator] = HassKey(f"{DOMAIN}_apps")
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
-PLATFORMS = [Platform.MEDIA_PLAYER]
+PLATFORMS = [Platform.MEDIA_PLAYER, Platform.REMOTE]
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/vizio/remote.py
+++ b/homeassistant/components/vizio/remote.py
@@ -1,0 +1,116 @@
+"""Remote platform for Vizio SmartCast devices."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterable
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.remote import (
+    ATTR_DELAY_SECS,
+    ATTR_NUM_REPEATS,
+    DEFAULT_DELAY_SECS,
+    RemoteEntity,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import VizioConfigEntry, VizioDeviceCoordinator
+
+PARALLEL_UPDATES = 0
+
+# Aliases keyed by actual pyvizio key name, values are human-friendly/HA-standard names.
+# Inverted at module level into _ALIAS_LOOKUP for O(1) resolution.
+REMOTE_KEY_ALIASES: dict[str, list[str]] = {
+    "CC_TOGGLE": ["closed_captions", "cc"],
+    "CH_DOWN": ["channel_down"],
+    "CH_PREV": ["previous_channel"],
+    "CH_UP": ["channel_up"],
+    "INPUT_NEXT": ["next_input"],
+    "MUTE_TOGGLE": ["mute"],
+    "OK": ["enter", "select"],
+    "PIC_MODE": ["picture_mode"],
+    "PIC_SIZE": ["picture_size"],
+    "POW_OFF": ["off", "power_off"],
+    "POW_ON": ["on", "power_on"],
+    "POW_TOGGLE": ["power_toggle"],
+    "SEEK_BACK": ["reverse", "rewind"],
+    "SEEK_FWD": ["forward", "fast_forward", "ff"],
+    "VOL_DOWN": ["volume_down"],
+    "VOL_UP": ["volume_up"],
+}
+
+_ALIAS_LOOKUP: dict[str, str] = {
+    alias: key for key, aliases in REMOTE_KEY_ALIASES.items() for alias in aliases
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: VizioConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up a Vizio remote entity."""
+    async_add_entities([VizioRemote(config_entry)])
+
+
+class VizioRemote(CoordinatorEntity[VizioDeviceCoordinator], RemoteEntity):
+    """Remote entity for Vizio SmartCast devices."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, config_entry: VizioConfigEntry) -> None:
+        """Initialize the remote entity."""
+        coordinator = config_entry.runtime_data.device_coordinator
+        super().__init__(coordinator)
+        unique_id = config_entry.unique_id
+        assert unique_id
+        self._attr_unique_id = unique_id
+        self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, unique_id)})
+        self._device = coordinator.device
+        valid_keys = set(self._device.get_remote_keys_list())
+        self._command_map: dict[str, str] = {key: key for key in valid_keys}
+        for alias, target in _ALIAS_LOOKUP.items():
+            if target in valid_keys:
+                self._command_map[alias.upper()] = target
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if device is on."""
+        return self.coordinator.data.is_on
+
+    def _resolve_command(self, command: str) -> str:
+        """Resolve an uppercased command string to a pyvizio key name."""
+        if resolved := self._command_map.get(command):
+            return resolved
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="unknown_command",
+            translation_placeholders={"command": command},
+        )
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the device."""
+        await self._device.pow_on(log_api_exception=False)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the device."""
+        await self._device.pow_off(log_api_exception=False)
+
+    async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
+        """Send remote commands to the device."""
+        num_repeats: int = kwargs.get(ATTR_NUM_REPEATS, 1)
+        delay: float = kwargs.get(ATTR_DELAY_SECS, DEFAULT_DELAY_SECS)
+        resolve = vol.All(vol.Upper, self._resolve_command)
+        resolved = [resolve(cmd) for cmd in command]
+
+        for _ in range(num_repeats):
+            for cmd in resolved:
+                await self._device.remote(cmd, log_api_exception=False)
+            await asyncio.sleep(delay)

--- a/homeassistant/components/vizio/strings.json
+++ b/homeassistant/components/vizio/strings.json
@@ -40,6 +40,11 @@
       }
     }
   },
+  "exceptions": {
+    "unknown_command": {
+      "message": "Unknown remote command `{command}`. Valid commands for this device are listed in the integration documentation."
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/tests/components/vizio/test_remote.py
+++ b/tests/components/vizio/test_remote.py
@@ -1,0 +1,306 @@
+"""Tests for Vizio remote platform."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.remote import (
+    ATTR_COMMAND,
+    DOMAIN as REMOTE_DOMAIN,
+    SERVICE_SEND_COMMAND,
+)
+from homeassistant.components.vizio.const import DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import slugify
+
+from .const import MOCK_SPEAKER_CONFIG, MOCK_USER_VALID_TV_CONFIG, NAME, UNIQUE_ID
+
+from tests.common import MockConfigEntry
+
+REMOTE_ENTITY_ID = f"{REMOTE_DOMAIN}.{slugify(NAME)}"
+
+
+async def _setup_entry(
+    hass: HomeAssistant, config: dict, unique_id: str = UNIQUE_ID
+) -> MockConfigEntry:
+    """Set up a Vizio config entry and return it."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data=config, unique_id=unique_id)
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    return config_entry
+
+
+@pytest.mark.parametrize(
+    "config",
+    [MOCK_USER_VALID_TV_CONFIG, MOCK_SPEAKER_CONFIG],
+    ids=["tv", "speaker"],
+)
+@pytest.mark.usefixtures("vizio_connect", "vizio_update")
+async def test_remote_entity_setup(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    config: dict,
+) -> None:
+    """Test remote entity is created for TV and speaker."""
+    await _setup_entry(hass, config)
+    state = hass.states.get(REMOTE_ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_ON
+
+    entry = entity_registry.async_get(REMOTE_ENTITY_ID)
+    assert entry is not None
+    assert entry.unique_id == UNIQUE_ID
+
+
+@pytest.mark.usefixtures("vizio_connect", "vizio_update")
+async def test_remote_is_off_when_device_off(hass: HomeAssistant) -> None:
+    """Test remote state is off when device is off."""
+    with patch(
+        "homeassistant.components.vizio.VizioAsync.get_power_state",
+        return_value=False,
+    ):
+        await _setup_entry(hass, MOCK_SPEAKER_CONFIG)
+        state = hass.states.get(REMOTE_ENTITY_ID)
+        assert state.state == STATE_OFF
+
+
+@pytest.mark.parametrize(
+    ("service", "mock_method"),
+    [
+        (SERVICE_TURN_ON, "pow_on"),
+        (SERVICE_TURN_OFF, "pow_off"),
+    ],
+)
+@pytest.mark.usefixtures("vizio_connect", "vizio_update")
+async def test_turn_on_off(hass: HomeAssistant, service: str, mock_method: str) -> None:
+    """Test turning on/off the remote sends the correct power command."""
+    await _setup_entry(hass, MOCK_SPEAKER_CONFIG)
+    with patch(
+        f"homeassistant.components.vizio.VizioAsync.{mock_method}",
+    ) as mock_power:
+        await hass.services.async_call(
+            REMOTE_DOMAIN,
+            service,
+            {ATTR_ENTITY_ID: REMOTE_ENTITY_ID},
+            blocking=True,
+        )
+        mock_power.assert_called_once_with(log_api_exception=False)
+
+
+@pytest.mark.parametrize(
+    ("command", "expected_key"),
+    [
+        # Native keys (lowercase tested for a few to verify case-insensitivity)
+        ("BACK", "BACK"),
+        ("CC_TOGGLE", "CC_TOGGLE"),
+        ("CH_DOWN", "CH_DOWN"),
+        ("CH_PREV", "CH_PREV"),
+        ("ch_up", "CH_UP"),
+        ("DOWN", "DOWN"),
+        ("EXIT", "EXIT"),
+        ("HOME", "HOME"),
+        ("INFO", "INFO"),
+        ("INPUT_NEXT", "INPUT_NEXT"),
+        ("LEFT", "LEFT"),
+        ("LEFT2", "LEFT2"),
+        ("menu", "MENU"),
+        ("MUTE_OFF", "MUTE_OFF"),
+        ("MUTE_ON", "MUTE_ON"),
+        ("MUTE_TOGGLE", "MUTE_TOGGLE"),
+        ("OK", "OK"),
+        ("PAUSE", "PAUSE"),
+        ("PIC_MODE", "PIC_MODE"),
+        ("PIC_SIZE", "PIC_SIZE"),
+        ("PLAY", "PLAY"),
+        ("POW_OFF", "POW_OFF"),
+        ("POW_ON", "POW_ON"),
+        ("POW_TOGGLE", "POW_TOGGLE"),
+        ("RIGHT", "RIGHT"),
+        ("SEEK_BACK", "SEEK_BACK"),
+        ("SEEK_FWD", "SEEK_FWD"),
+        ("SMARTCAST", "SMARTCAST"),
+        ("UP", "UP"),
+        ("VOL_DOWN", "VOL_DOWN"),
+        ("VOL_UP", "VOL_UP"),
+        # Aliases
+        ("closed_captions", "CC_TOGGLE"),
+        ("cc", "CC_TOGGLE"),
+        ("channel_down", "CH_DOWN"),
+        ("previous_channel", "CH_PREV"),
+        ("channel_up", "CH_UP"),
+        ("next_input", "INPUT_NEXT"),
+        ("mute", "MUTE_TOGGLE"),
+        ("enter", "OK"),
+        ("select", "OK"),
+        ("picture_mode", "PIC_MODE"),
+        ("picture_size", "PIC_SIZE"),
+        ("off", "POW_OFF"),
+        ("power_off", "POW_OFF"),
+        ("on", "POW_ON"),
+        ("power_on", "POW_ON"),
+        ("power_toggle", "POW_TOGGLE"),
+        ("reverse", "SEEK_BACK"),
+        ("rewind", "SEEK_BACK"),
+        ("forward", "SEEK_FWD"),
+        ("fast_forward", "SEEK_FWD"),
+        ("ff", "SEEK_FWD"),
+        ("volume_down", "VOL_DOWN"),
+        ("volume_up", "VOL_UP"),
+    ],
+)
+@pytest.mark.usefixtures("vizio_connect", "vizio_update")
+async def test_send_command_tv_valid(
+    hass: HomeAssistant, command: str, expected_key: str
+) -> None:
+    """Test send_command resolves valid TV commands."""
+    await _setup_entry(hass, MOCK_USER_VALID_TV_CONFIG)
+    with patch(
+        "homeassistant.components.vizio.VizioAsync.remote",
+    ) as mock_remote:
+        await hass.services.async_call(
+            REMOTE_DOMAIN,
+            SERVICE_SEND_COMMAND,
+            {ATTR_ENTITY_ID: REMOTE_ENTITY_ID, ATTR_COMMAND: [command]},
+            blocking=True,
+        )
+        mock_remote.assert_called_once_with(expected_key, log_api_exception=False)
+
+
+@pytest.mark.parametrize("command", ["INVALID_KEY", "not_a_key"])
+@pytest.mark.usefixtures("vizio_connect", "vizio_update")
+async def test_send_command_tv_invalid(hass: HomeAssistant, command: str) -> None:
+    """Test send_command raises error for invalid TV commands."""
+    await _setup_entry(hass, MOCK_USER_VALID_TV_CONFIG)
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            REMOTE_DOMAIN,
+            SERVICE_SEND_COMMAND,
+            {ATTR_ENTITY_ID: REMOTE_ENTITY_ID, ATTR_COMMAND: [command]},
+            blocking=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("command", "expected_key"),
+    [
+        # Native keys (lowercase tested for a couple)
+        ("MUTE_OFF", "MUTE_OFF"),
+        ("MUTE_ON", "MUTE_ON"),
+        ("MUTE_TOGGLE", "MUTE_TOGGLE"),
+        ("pause", "PAUSE"),
+        ("PLAY", "PLAY"),
+        ("POW_OFF", "POW_OFF"),
+        ("POW_ON", "POW_ON"),
+        ("POW_TOGGLE", "POW_TOGGLE"),
+        ("vol_down", "VOL_DOWN"),
+        ("VOL_UP", "VOL_UP"),
+        # Aliases (only those whose target is a speaker key)
+        ("mute", "MUTE_TOGGLE"),
+        ("off", "POW_OFF"),
+        ("power_off", "POW_OFF"),
+        ("on", "POW_ON"),
+        ("power_on", "POW_ON"),
+        ("power_toggle", "POW_TOGGLE"),
+        ("volume_down", "VOL_DOWN"),
+        ("volume_up", "VOL_UP"),
+    ],
+)
+@pytest.mark.usefixtures("vizio_connect", "vizio_update")
+async def test_send_command_speaker_valid(
+    hass: HomeAssistant, command: str, expected_key: str
+) -> None:
+    """Test send_command resolves valid speaker commands."""
+    await _setup_entry(hass, MOCK_SPEAKER_CONFIG)
+    with patch(
+        "homeassistant.components.vizio.VizioAsync.remote",
+    ) as mock_remote:
+        await hass.services.async_call(
+            REMOTE_DOMAIN,
+            SERVICE_SEND_COMMAND,
+            {ATTR_ENTITY_ID: REMOTE_ENTITY_ID, ATTR_COMMAND: [command]},
+            blocking=True,
+        )
+        mock_remote.assert_called_once_with(expected_key, log_api_exception=False)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # TV-only native keys
+        "MENU",
+        "CH_UP",
+        "INPUT_NEXT",
+        # TV-only aliases
+        "channel_up",
+        "enter",
+        "next_input",
+        # Completely invalid
+        "INVALID_KEY",
+    ],
+)
+@pytest.mark.usefixtures("vizio_connect", "vizio_update")
+async def test_send_command_speaker_invalid(hass: HomeAssistant, command: str) -> None:
+    """Test speaker remote rejects TV-only and invalid keys."""
+    await _setup_entry(hass, MOCK_SPEAKER_CONFIG)
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            REMOTE_DOMAIN,
+            SERVICE_SEND_COMMAND,
+            {ATTR_ENTITY_ID: REMOTE_ENTITY_ID, ATTR_COMMAND: [command]},
+            blocking=True,
+        )
+
+
+@pytest.mark.usefixtures("vizio_connect", "vizio_update")
+async def test_send_command_multiple(hass: HomeAssistant) -> None:
+    """Test send_command with multiple commands in one call."""
+    await _setup_entry(hass, MOCK_USER_VALID_TV_CONFIG)
+    with patch(
+        "homeassistant.components.vizio.VizioAsync.remote",
+    ) as mock_remote:
+        await hass.services.async_call(
+            REMOTE_DOMAIN,
+            SERVICE_SEND_COMMAND,
+            {
+                ATTR_ENTITY_ID: REMOTE_ENTITY_ID,
+                ATTR_COMMAND: ["UP", "OK"],
+            },
+            blocking=True,
+        )
+        assert mock_remote.call_count == 2
+        mock_remote.assert_any_call("UP", log_api_exception=False)
+        mock_remote.assert_any_call("OK", log_api_exception=False)
+
+
+@pytest.mark.usefixtures("vizio_connect", "vizio_update")
+async def test_send_command_invalid_skips_valid(hass: HomeAssistant) -> None:
+    """Test that no commands are sent when one command in the list is invalid."""
+    await _setup_entry(hass, MOCK_USER_VALID_TV_CONFIG)
+    with (
+        patch(
+            "homeassistant.components.vizio.VizioAsync.remote",
+        ) as mock_remote,
+        pytest.raises(ServiceValidationError),
+    ):
+        await hass.services.async_call(
+            REMOTE_DOMAIN,
+            SERVICE_SEND_COMMAND,
+            {
+                ATTR_ENTITY_ID: REMOTE_ENTITY_ID,
+                ATTR_COMMAND: ["UP", "INVALID_KEY"],
+            },
+            blocking=True,
+        )
+    mock_remote.assert_not_called()


### PR DESCRIPTION
## Breaking change

N/A

## Proposed change

Adds a `remote` platform to the Vizio integration, giving users `remote.send_command` access to all native pyvizio remote keys (e.g. `UP`, `MENU`, `VOL_UP`) plus human-friendly aliases (e.g. `enter` → `OK`, `mute` → `MUTE_TOGGLE`, `on` → `POW_ON`).

Key design decisions:
- **Supports both TVs and speakers** — the command map is filtered per device type at init, so speakers only accept speaker-valid keys
- **Case-insensitive input** — commands are uppercased via `vol.Upper` before resolution
- **Fail-fast validation** — all commands in a list are resolved up front via voluptuous before any are sent to the device, so an invalid key in the middle won't cause a partial send
- **Precomputed command map** — a single `dict[str, str]` built at init combines native keys and aliases, making resolution a simple dict lookup

> **Depends on:** home-assistant/core#162188 (Refactor Vizio integration to use DataUpdateCoordinator)

## Type of change

- [x] New feature (which adds functionality to an existing integration)

## Additional information

- This PR is related to issue:
- This PR is related to discussion: https://github.com/orgs/home-assistant/discussions/675
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr