### PR TITLE
Add command aliases to Vizio remote platform

### DIFF
--- a/homeassistant/components/vizio/remote.py
+++ b/homeassistant/components/vizio/remote.py
@@ -25,6 +25,31 @@ from .coordinator import VizioConfigEntry, VizioDeviceCoordinator
 
 PARALLEL_UPDATES = 0
 
+# Aliases keyed by actual pyvizio key name, values are human-friendly/HA-standard names.
+# Inverted at module level into _ALIAS_LOOKUP for O(1) resolution.
+REMOTE_KEY_ALIASES: dict[str, list[str]] = {
+    "CC_TOGGLE": ["closed_captions", "cc"],
+    "CH_DOWN": ["channel_down"],
+    "CH_PREV": ["previous_channel"],
+    "CH_UP": ["channel_up"],
+    "INPUT_NEXT": ["next_input"],
+    "MUTE_TOGGLE": ["mute"],
+    "OK": ["enter", "select"],
+    "PIC_MODE": ["picture_mode"],
+    "PIC_SIZE": ["picture_size"],
+    "POW_OFF": ["off", "power_off"],
+    "POW_ON": ["on", "power_on"],
+    "POW_TOGGLE": ["power_toggle"],
+    "SEEK_BACK": ["reverse", "rewind"],
+    "SEEK_FWD": ["forward", "fast_forward", "ff"],
+    "VOL_DOWN": ["volume_down"],
+    "VOL_UP": ["volume_up"],
+}
+
+_ALIAS_LOOKUP: dict[str, str] = {
+    alias: key for key, aliases in REMOTE_KEY_ALIASES.items() for alias in aliases
+}
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -52,6 +77,9 @@ class VizioRemote(CoordinatorEntity[VizioDeviceCoordinator], RemoteEntity):
         self._device = coordinator.device
         valid_keys = set(self._device.get_remote_keys_list())
         self._command_map: dict[str, str] = {key: key for key in valid_keys}
+        for alias, target in _ALIAS_LOOKUP.items():
+            if target in valid_keys:
+                self._command_map[alias.upper()] = target
 
     @property
     def is_on(self) -> bool:

--- a/tests/components/vizio/test_remote.py
+++ b/tests/components/vizio/test_remote.py
@@ -134,6 +134,30 @@ async def test_turn_on_off(hass: HomeAssistant, service: str, mock_method: str) 
         ("UP", "UP"),
         ("VOL_DOWN", "VOL_DOWN"),
         ("VOL_UP", "VOL_UP"),
+        # Aliases
+        ("closed_captions", "CC_TOGGLE"),
+        ("cc", "CC_TOGGLE"),
+        ("channel_down", "CH_DOWN"),
+        ("previous_channel", "CH_PREV"),
+        ("channel_up", "CH_UP"),
+        ("next_input", "INPUT_NEXT"),
+        ("mute", "MUTE_TOGGLE"),
+        ("enter", "OK"),
+        ("select", "OK"),
+        ("picture_mode", "PIC_MODE"),
+        ("picture_size", "PIC_SIZE"),
+        ("off", "POW_OFF"),
+        ("power_off", "POW_OFF"),
+        ("on", "POW_ON"),
+        ("power_on", "POW_ON"),
+        ("power_toggle", "POW_TOGGLE"),
+        ("reverse", "SEEK_BACK"),
+        ("rewind", "SEEK_BACK"),
+        ("forward", "SEEK_FWD"),
+        ("fast_forward", "SEEK_FWD"),
+        ("ff", "SEEK_FWD"),
+        ("volume_down", "VOL_DOWN"),
+        ("volume_up", "VOL_UP"),
     ],
 )
 @pytest.mark.usefixtures("vizio_connect", "vizio_update")
@@ -182,6 +206,15 @@ async def test_send_command_tv_invalid(hass: HomeAssistant, command: str) -> Non
         ("POW_TOGGLE", "POW_TOGGLE"),
         ("vol_down", "VOL_DOWN"),
         ("VOL_UP", "VOL_UP"),
+        # Aliases (only those whose target is a speaker key)
+        ("mute", "MUTE_TOGGLE"),
+        ("off", "POW_OFF"),
+        ("power_off", "POW_OFF"),
+        ("on", "POW_ON"),
+        ("power_on", "POW_ON"),
+        ("power_toggle", "POW_TOGGLE"),
+        ("volume_down", "VOL_DOWN"),
+        ("volume_up", "VOL_UP"),
     ],
 )
 @pytest.mark.usefixtures("vizio_connect", "vizio_update")
@@ -209,6 +242,10 @@ async def test_send_command_speaker_valid(
         "MENU",
         "CH_UP",
         "INPUT_NEXT",
+        # TV-only aliases
+        "channel_up",
+        "enter",
+        "next_input",
         # Completely invalid
         "INVALID_KEY",
     ],


### PR DESCRIPTION
## Proposed change

Add human-friendly command aliases for the Vizio remote platform, mapping common names to pyvizio native key names:

- `mute` → `MUTE_TOGGLE`, `channel_up` → `CH_UP`, `volume_down` → `VOL_DOWN`, etc.
- Aliases are filtered per device type at init time (speakers only get speaker-valid aliases)
- O(1) lookup via precomputed `_command_map` dict

> **Note:** This PR targets `vizio-remote-platform`. Once home-assistant/core#165820 merges, retarget to `dev` and open upstream PR.

## Test plan

- [x] 88 parametrized tests pass (54 without aliases, 34 alias-specific)
- [x] All native keys + aliases tested for both TV and speaker device types
- [x] Invalid alias resolution tested (TV-only aliases rejected on speaker)

## Summary by Sourcery

Add human-friendly command aliases to the Vizio remote platform and ensure they are correctly resolved and validated per device type.

New Features:
- Support human-friendly/standardized command aliases for Vizio TV and speaker remotes, mapped to underlying pyvizio key codes.

Enhancements:
- Precompute a command lookup map per device to support O(1) resolution of both native keys and aliases, filtered to only keys supported by that device.

Tests:
- Expand Vizio remote tests to cover alias-to-key resolution for TVs and speakers and to verify invalid or device-inappropriate aliases are rejected.